### PR TITLE
Allow negative offsets for off-beat articulations

### DIFF
--- a/DockArticulate.qml
+++ b/DockArticulate.qml
@@ -227,7 +227,7 @@ MuseScore {
    }
 
     function is_num(val) {
-	return /^\d+$/.test(val);
+	return /^-?\d+$/.test(val); // Allow negative values for off-beat articulations
     }
 
     function applyChanges() {


### PR DESCRIPTION
I changed the `is_num` check in order to allow for negative offsets to create appoggiatura starting off-beat and ending on-beat.